### PR TITLE
fix(create sdk task): fix base_sdk_id param

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zapp_sdk_tasks (0.1.0)
+    zapp_sdk_tasks (0.2.2)
       aws-sdk-s3 (~> 1)
       faraday (~> 0.15.3)
       rake (~> 11.0)
@@ -12,8 +12,8 @@ GEM
   specs:
     ast (2.4.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.117.0)
-    aws-sdk-core (3.40.0)
+    aws-partitions (1.121.0)
+    aws-sdk-core (3.42.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -21,7 +21,7 @@ GEM
     aws-sdk-kms (1.13.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.27.0)
+    aws-sdk-s3 (1.29.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)

--- a/lib/zapp_sdk_tasks/sdk_helper.rb
+++ b/lib/zapp_sdk_tasks/sdk_helper.rb
@@ -27,6 +27,7 @@ class SdkHelper
         build_branch: preview?(request_options[:version]) ? request_options[:version] : "release"
       },
       use_latest_dev: base_sdk_id(request_options[:version]).to_s.empty?,
+      base_sdk_version_id: base_sdk_id(request_options[:version]),
       access_token: ENV["ZAPP_TOKEN"] || request_options[:zapp_token]
     }
   end

--- a/lib/zapp_sdk_tasks/version.rb
+++ b/lib/zapp_sdk_tasks/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZappSdkTasks
-  VERSION = "0.2.0"
+  VERSION = "0.2.2"
 end

--- a/spec/lib/tasks/create_sdk_spec.rb
+++ b/spec/lib/tasks/create_sdk_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "zapp_sdks:create", type: :rake do
           build_branch: "1.0-preview1"
         },
         use_latest_dev: true,
+        base_sdk_version_id: nil,
         access_token: "1234"
       }
     end
@@ -88,6 +89,7 @@ RSpec.describe "zapp_sdks:create", type: :rake do
           build_branch: "release"
         },
         use_latest_dev: false,
+        base_sdk_version_id: "12345",
         access_token: "1234"
       }
     end
@@ -124,6 +126,7 @@ RSpec.describe "zapp_sdks:create", type: :rake do
           build_branch: "release"
         },
         use_latest_dev: true,
+        base_sdk_version_id: nil,
         access_token: "1234"
       }
     end


### PR DESCRIPTION
Fixing `base_sdk_id` param - it was inside `sdk_version` object and it is required to be outside the object.