### PR TITLE
fix: fix tasks path

### DIFF
--- a/lib/zapp_sdk_tasks.rb
+++ b/lib/zapp_sdk_tasks.rb
@@ -9,7 +9,7 @@ module ZappSdkTasks
     def install_tasks
       path = File.expand_path(__dir__)
       $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), "lib"))
-      Dir.glob("#{path}/lib/**/*.rake").each { |f| load f }
+      Dir.glob("#{path}/**/*.rake").each { |f| load f }
     end
   end
 end


### PR DESCRIPTION
## Definition
The rake tasks where not accessible when using the gem, due to wrong path in `install_tasks` method. 