### PR TITLE
feat: add scm tag arg to create task

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Make sure the params are comma-separated without whitespaces
 
 | param           | description                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| platform        | The platform supported by the current published sdk (Currently supporting `android/ios/roku/tvos/samsung_tv`)                   |
+| platform        | The platform supported by the current published sdk (Currently supporting `android/ios/roku/tvos/samsung_tv/lg_tv/vizio`)       |
 | version         | The requireed version for the published sdk. _Note: only semver stable/final and preview versions will publish the sdk in zapp_ |
 | repository name | The sdk repo name                                                                                                               |
 | zapp token      | Zapp API access token                                                                                                           |
@@ -65,10 +65,10 @@ Make sure the params are comma-separated without whitespaces
 
 **Params**
 
-| param    | description                                                                                                   |
-| -------- | ------------------------------------------------------------------------------------------------------------- |
-| platform | The platform supported by the current published sdk (Currently supporting `android/ios/roku/tvos/samsung_tv`) |
-| version  | The requireed version for the published sdk                                                                   |
+| param    | description                                                                                                               |
+| -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| platform | The platform supported by the current published sdk (Currently supporting `android/ios/roku/tvos/samsung_tv/lg_tv/vizio`) |
+| version  | The requireed version for the published sdk                                                                               |
 
 #### Upload Development Project
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repo provides various rake tasks to be used on any new Zapp sdk repo you
 create.
 
 ## Installation
+
 **Prerequisites**
 
 ```
@@ -44,17 +45,17 @@ Make sure the params are comma-separated without whitespaces
 
 **Params**
 
-param        | description
-----------------|-------------|
-platform        | The platform supported by the current published sdk (Currently supporting `android/ios/roku/tvos/samsung_tv`)   |
-version         | The requireed version for the published sdk. *Note: only semver stable/final and preview versions will publish the sdk in zapp* |
-repository name | The sdk repo name  |
-zapp token      | Zapp API access token  |
+| param           | description                                                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| platform        | The platform supported by the current published sdk (Currently supporting `android/ios/roku/tvos/samsung_tv`)                   |
+| version         | The requireed version for the published sdk. _Note: only semver stable/final and preview versions will publish the sdk in zapp_ |
+| repository name | The sdk repo name                                                                                                               |
+| zapp token      | Zapp API access token                                                                                                           |
 
 #### Publish Changelog
 
 This task creates and publish changelog to Amazon s3.
-**Make sure you setup `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` environment variable in order to use this task.
+\*\*Make sure you setup `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` environment variable in order to use this task.
 
 Run:
 
@@ -64,15 +65,15 @@ Make sure the params are comma-separated without whitespaces
 
 **Params**
 
-param        | description
-----------------|-------------|
-platform        | The platform supported by the current published sdk (Currently supporting `android/ios/roku/tvos/samsung_tv`)   |
-version         | The requireed version for the published sdk  |
+| param    | description                                                                                                   |
+| -------- | ------------------------------------------------------------------------------------------------------------- |
+| platform | The platform supported by the current published sdk (Currently supporting `android/ios/roku/tvos/samsung_tv`) |
+| version  | The requireed version for the published sdk                                                                   |
 
 #### Upload Development Project
 
 This task uploads the Development project to Amazon s3, and updates Zapp.
-**Make sure you setup `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ZAPP_TOKEN` environment variable in order to use this task.
+\*\*Make sure you setup `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ZAPP_TOKEN` environment variable in order to use this task.
 
 Run:
 
@@ -80,9 +81,9 @@ Run:
 
 **Params**
 
-param        | description
-----------------|-------------|
-file path       | Path to the development project file    |
+| param     | description                          |
+| --------- | ------------------------------------ |
+| file path | Path to the development project file |
 
 ## Development
 
@@ -96,4 +97,4 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/applic
 
 ## Code of Conduct
 
-Everyone interacting in the ZappSdkTasks project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/applicaster/zapp_sdk_tasks/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the ZappSdkTasks project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/applicaster/zapp_sdk_tasks/blob/master/CODE_OF_CONDUCT.md).

--- a/lib/zapp_sdk_tasks/sdk_helper.rb
+++ b/lib/zapp_sdk_tasks/sdk_helper.rb
@@ -23,7 +23,7 @@ class SdkHelper
         ci_provider: "circle_ci",
         ci_project_id: request_options[:project_repo_name],
         base_sdk_version_id: base_sdk_id(request_options[:version]),
-        scm_tag: request_options[:version],
+        scm_tag: request_options[:scm_tag] || request_options[:version],
         build_branch: preview?(request_options[:version]) ? request_options[:version] : "release"
       },
       use_latest_dev: base_sdk_id(request_options[:version]).to_s.empty?,

--- a/lib/zapp_sdk_tasks/tasks/create_sdk.rake
+++ b/lib/zapp_sdk_tasks/tasks/create_sdk.rake
@@ -8,7 +8,7 @@ require "zapp_sdk_tasks/sdk_helper"
 
 desc "Create SDK version on Zapp"
 namespace :zapp_sdks do
-  task :create, :platform, :version, :project_repo_name, :zapp_token do |_task, args|
+  task :create, :platform, :version, :project_repo_name, :zapp_token, :scm_tag do |_task, args|
     begin
       if SdkHelper.triggered_by_zapp?
         puts "skipping sdk creation, was triggered by Zapp CMS"

--- a/spec/lib/tasks/create_sdk_spec.rb
+++ b/spec/lib/tasks/create_sdk_spec.rb
@@ -144,6 +144,43 @@ RSpec.describe "zapp_sdks:create", type: :rake do
     end
   end
 
+  context "when a custom scm_tag is provided" do
+    let(:response) { double("response", success?: true) }
+
+    before do
+      allow(GitHelper).to receive(:last_commit_message).and_return("commit message")
+    end
+
+    it "send request with the correct custom scm_tag" do
+      expect(connection).to receive(:post)
+        .with("api/v1/sdk_creation_workers", request_params)
+        .and_return(response)
+
+      Rake::Task["zapp_sdks:create"].invoke("android", "1.0", "zapp-android", nil, "android-1.0")
+    end
+
+    def request_params
+      {
+        sdk_version: {
+          version: "1.0",
+          platform: "android",
+          screen_sizes: ["universal"],
+          status: "stable",
+          official: true,
+          channel: "stable_channel",
+          ci_provider: "circle_ci",
+          ci_project_id: "zapp-android",
+          base_sdk_version_id: nil,
+          scm_tag: "android-1.0",
+          build_branch: "release"
+        },
+        use_latest_dev: true,
+        base_sdk_version_id: nil,
+        access_token: "1234"
+      }
+    end
+  end
+
   context "when request fails" do
     let(:response) { double("response", success?: false, status: 500) }
 


### PR DESCRIPTION
# Description

Add optional SCM tag parameter to SDK creation task

## Overview
This PR adds an optional `scm_tag` parameter to the `zapp_sdks:create` rake task, allowing users to specify a custom SCM tag that differs from the version number.

## Background
Currently, the `zapp_sdk_tasks` gem hardcodes the SCM tag to match the version number. However, for platform-specific releases like [TV 7.0.2](https://github.com/applicaster/zapp-web-tvs/releases/tag/tv-7.0.2), we need the ability to use platform-specific tags (e.g., `webos-7.0.2`, `tizen-7.0.2`) while maintaining the same base version number.

## Changes
- Added an optional `scm_tag` parameter to the `zapp_sdks:create` rake task
- Updated the `SdkHelper.zapp_request_params` method to use the provided SCM tag, falling back to the version if not provided
- Added appropriate test cases for the new functionality
- Updated the README to document the new parameter and include the additional supported platforms (samsung_tv, lg_tv, vizio)

## Testing
All specs have been updated and tested with:
- No SCM tag provided (maintains backward compatibility)
- Custom SCM tag provided

## Example Usage
Before:
```bash
bundle exec rake zapp_sdks:create[webos,7.0.2,zapp-web-tvs,token]
# Uses scm_tag = "7.0.2"
```

After:
```bash
bundle exec rake zapp_sdks:create[webos,7.0.2,zapp-web-tvs,token,webos-7.0.2]
# Uses scm_tag = "webos-7.0.2"
```

## Backward Compatibility
This change is fully backward compatible. Existing scripts that don't provide the SCM tag will continue to work as before, using the version as the SCM tag.